### PR TITLE
Fix MediatR assemlby registration to work out the box

### DIFF
--- a/Rhodium24.Host/Program.cs
+++ b/Rhodium24.Host/Program.cs
@@ -52,7 +52,9 @@ namespace Rhodium24.Host
                     services.AddHostedService<AgentOutputFileWatcherService>();
 
                     // register MediatR with current assembly
-                    services.AddMediatR(typeof(AgentOutputFileWatcherService).Assembly);
+                    services.AddMediatR(
+                        cfg => {cfg.RegisterServicesFromAssembly(typeof(AgentOutputFileWatcherService).Assembly);}
+                    );
                 });
     }
 }


### PR DESCRIPTION
Fix assembly registration to mitigate the following error with the vanilla solution;

![image](https://github.com/QuotationFactory/QF.Basic.Integration.Quickstart/assets/12949389/646a53ff-9fae-492a-8900-5cec0ca04fa0)
